### PR TITLE
Fix launcher not working all the time

### DIFF
--- a/src/jvmMain/kotlin/io/github/fourlastor/settings/SettingsViewModel.kt
+++ b/src/jvmMain/kotlin/io/github/fourlastor/settings/SettingsViewModel.kt
@@ -85,11 +85,9 @@ class SettingsViewModel constructor(
         }.toTypedArray()
 
         scope.launch(newSingleThreadContext("pokeWildsJar")) {
-            val proc = Runtime.getRuntime().exec(
-                runArgs,
-                null,
-                File(state.dir)
-            )
+            val proc = ProcessBuilder(*runArgs)
+                .directory(File(state.dir))
+                .start()
 
             if (state.logsEnabled) {
                 val stdInput = BufferedReader(InputStreamReader(proc.inputStream))

--- a/src/jvmMain/kotlin/io/github/fourlastor/settings/SettingsViewModel.kt
+++ b/src/jvmMain/kotlin/io/github/fourlastor/settings/SettingsViewModel.kt
@@ -87,13 +87,17 @@ class SettingsViewModel constructor(
 
         scope.launch(newSingleThreadContext("pokeWildsJar")) {
             try {
-                appendLog("Running ${runArgs.joinToString(" ")}")
+                if (state.logsEnabled) {
+                    appendLog("Running ${runArgs.joinToString(" ")}")
+                }
                 val proc = ProcessBuilder(*runArgs)
                     .directory(File(state.dir))
                     .start()
                 captureLogs(state, proc)
             } catch (exception: Throwable) {
-                appendLog(exception.fullTrace())
+                if (state.logsEnabled) {
+                    appendLog(exception.fullTrace())
+                }
             }
 
         }

--- a/src/jvmMain/kotlin/io/github/fourlastor/settings/SettingsViewModel.kt
+++ b/src/jvmMain/kotlin/io/github/fourlastor/settings/SettingsViewModel.kt
@@ -75,7 +75,8 @@ class SettingsViewModel constructor(
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun runPokeWilds(state: SettingsState.Loaded) {
-        val runArgs = mutableListOf("java", "-jar", state.jar).apply {
+        val jarFile = File(File(state.dir), state.jar)
+        val runArgs = mutableListOf("java", "-jar", jarFile.absolutePath).apply {
             if (state.angleGles20) {
                 add("angle_gles20")
             }

--- a/src/jvmMain/kotlin/io/github/fourlastor/settings/SettingsViewModel.kt
+++ b/src/jvmMain/kotlin/io/github/fourlastor/settings/SettingsViewModel.kt
@@ -86,6 +86,7 @@ class SettingsViewModel constructor(
 
         scope.launch(newSingleThreadContext("pokeWildsJar")) {
             try {
+                appendLog("Running ${runArgs.joinToString(" ")}")
                 val proc = ProcessBuilder(*runArgs)
                     .directory(File(state.dir))
                     .start()


### PR DESCRIPTION
This PR changes:

1. Uses `ProcessBuilder` instead of `Runtime`
2. Passes the full path to the jar file when launching pokewilds